### PR TITLE
Add 'export {jutge_api_client}' to support browsers env

### DIFF
--- a/src/clients/javascript/generator.ts
+++ b/src/clients/javascript/generator.ts
@@ -27,6 +27,7 @@ try {
     module.exports = { jutge_api_client }
 } catch (error) { }
 
+export { jutge_api_client };
 `
     const formatted = await format(source)
     return formatted


### PR DESCRIPTION
Hola!

Estic intentant integrar l'api del Jutge per CircuitVerse, sembla ser però que el 'hack' per poder fer servir a _browsers_ no funciona per aquest cas d'ús. He afegir una linea per estar en línia amb el que crec que són [els estàndards de ECMAScript Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) i em funciona.

Els tests passen, però no tinc clar si això substitueix o no el 'hack', ergo no l'he eliminat.
